### PR TITLE
Compatibility changes for 0.15.0

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "1.0.1",
     "summary": "Basic primitives for working with laziness",
     "repository": "http://github.com/maxsnew/lazy.git",
     "license": "BSD3",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "summary": "Basic primitives for working with laziness",
     "repository": "http://github.com/maxsnew/lazy.git",
     "license": "BSD3",

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,6 +11,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "1.0.0 <= v < 2.0.0"
-    }
+        "elm-lang/core": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.15.0 <= v < 0.16.0"
 }

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -17,7 +17,7 @@ module Lazy
 @docs apply, andThen
 -}
 
-import Native.Lazy exposing (..)
+import Native.Lazy
 
 
 type Lazy a = Lazy (() -> a)

--- a/src/Lazy.elm
+++ b/src/Lazy.elm
@@ -17,7 +17,7 @@ module Lazy
 @docs apply, andThen
 -}
 
-import Native.Lazy
+import Native.Lazy exposing (..)
 
 
 type Lazy a = Lazy (() -> a)


### PR DESCRIPTION
As the import syntax changed for 0.15, this package is no longer compatible with 0.15 packages. In addition, the elm-package.json file now requires an "elm-version" field. These changes update the import syntax in Lazy.elm to reflect the changes as well as add the required field in elm-package, changing the version of elm-core to 2.0.0 along the way.

In addition, I changed the version to 2.0.0, which would allow individuals to install a 0.14-compatible version of this application if they so desire.

It compiles for me after installing elm-core 2.0.0 and using the new version of elm-make (0.1.2).