### PR TITLE
Update for 0.16 only

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,7 +11,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 4.0.0"
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
Allowing two Elm versions at once seems to be the root cause of [this issue](https://groups.google.com/d/msg/elm-discuss/3YfvuKFUYNw/i3jM4f_QCQAJ) and probably many others. No one is on 0.15 anymore and if they are they can peg the old version.

Please release a patch version once merged.